### PR TITLE
Bump build number

### DIFF
--- a/FieldChooser.csproj
+++ b/FieldChooser.csproj
@@ -76,7 +76,9 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="build_plgx.bat" />
-    <None Include="FieldChooser.version" />
+    <None Include="FieldChooser.version">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/FieldChooser.version
+++ b/FieldChooser.version
@@ -1,3 +1,3 @@
 ﻿:
-FieldChooser:1.0
+FieldChooser:1.1
 :

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -9,9 +9,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("FieldChooser")]
 [assembly: AssemblyDescription("A plug in that allows you to choose individual characters from a field.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("david@davidhancock.net")]
+[assembly: AssemblyCompany("David Hancock")]
 [assembly: AssemblyProduct("KeePass Plugin")]
-[assembly: AssemblyCopyright("")]
+[assembly: AssemblyCopyright("Copyright 2019 David Hancock")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1")]
+[assembly: AssemblyFileVersion("1.1")]
 [assembly: NeutralResourcesLanguage("en")]
 

--- a/Source/FieldChooserExt.cs
+++ b/Source/FieldChooserExt.cs
@@ -113,16 +113,17 @@ namespace FieldChooser
         /// <summary>
         /// URL of a version information file. See
         /// https://keepass.info/help/v2_dev/plg_index.html#upd
-        /// 
-        /// Although this is the first released version and no updates will be
-        /// available this is required so KeePass can indicate that this plug in 
-        /// is up to date. See main menu Help -> Check For Updates
         /// </summary>
         public override string UpdateUrl
         {
             get
             {
+#if DEBUG
+                string dir = System.IO.Path.GetDirectoryName(typeof(FieldChooserExt).Assembly.Location);
+                return System.IO.Path.Combine(dir, "FieldChooser.version");
+#else
                 return "https://raw.githubusercontent.com/DHancock/FieldChooser/master/FieldChooser.version";
+#endif
             }
         }
 


### PR DESCRIPTION
Set build number and version file for next release. Add test code to debug builds only that checks the new version number (as its not yet been merged into master).