### PR TITLE
Improve how empty fields are handled

### DIFF
--- a/Source/FieldChooserExt.cs
+++ b/Source/FieldChooserExt.cs
@@ -25,7 +25,7 @@ using System.Windows.Forms;
 
 using KeePass.Plugins;
 using KeePassLib;
-
+using KeePassLib.Security;
 
 namespace FieldChooser
 {
@@ -61,7 +61,25 @@ namespace FieldChooser
         {
             if (m_MenuItems.Count > 0)
             {
-                bool enable = m_Host.MainWindow.GetSelectedEntriesCount() == 1;
+                bool enable = false;
+
+                if (m_Host.MainWindow.GetSelectedEntriesCount() == 1)
+                {
+                    // only enable if one of the selected entry's relevant fields has some data
+                    PwEntry entry = m_Host.MainWindow.GetSelectedEntry(true);
+
+                    foreach (KeyValuePair<string, ProtectedString> kvp in entry.Strings)
+                    {
+                        if (kvp.Value.Length == 0)
+                            continue;
+
+                        if ((kvp.Key == PwDefs.NotesField) || (kvp.Key == PwDefs.UrlField) || (kvp.Key == PwDefs.TitleField))
+                            continue;
+
+                        enable = true;
+                        break;
+                    }
+                }
 
                 foreach (ToolStripMenuItem menuItem in m_MenuItems)
                     menuItem.Enabled = enable;

--- a/Source/FieldChooserForm.cs
+++ b/Source/FieldChooserForm.cs
@@ -76,34 +76,32 @@ namespace FieldChooser
 
             foreach (KeyValuePair<string, ProtectedString> kvp in Fields)
             {
-                switch (kvp.Key)
+                if (kvp.Value.Length > 0)
                 {
-                    case PwDefs.NotesField:
-                    case PwDefs.UrlField:
-                    case PwDefs.TitleField: break; // filter these out
-
-                    // always add a password entry even if its empty
-                    case PwDefs.PasswordField: standardFields.Add(new FieldEntry(KPRes.Password, kvp.Value)); break;
-
-                    default:
+                    switch (kvp.Key)
                     {
-                        if (kvp.Value.Length > 0)   // add other fields, if not empty
-                        {
-                            if (kvp.Key == PwDefs.UserNameField)
-                                standardFields.Add(new FieldEntry(KPRes.UserName, kvp.Value));
-                            else
-                                userFields.Add(new FieldEntry(kvp.Key, kvp.Value));
-                        }
+                        case PwDefs.NotesField:
+                        case PwDefs.UrlField:
+                        case PwDefs.TitleField: break; // filter these out
 
-                        break;
+                        case PwDefs.PasswordField: standardFields.Add(new FieldEntry(KPRes.Password, kvp.Value)); break;
+                        case PwDefs.UserNameField: standardFields.Add(new FieldEntry(KPRes.UserName, kvp.Value)); break;
+
+                        default: userFields.Add(new FieldEntry(kvp.Key, kvp.Value)); break;
                     }
                 }
             }
 
-            // combine user and standard fields
-            // the keys are stored by KeePass in a sorted dictionary
-            standardFields.Sort();
-            standardFields.AddRange(userFields);
+            // the plugin's menu item shouldn't have been enabled
+            Debug.Assert((standardFields.Count > 0) || (userFields.Count > 0));
+
+            // sort the translated standard fields
+            if (standardFields.Count > 0)
+                standardFields.Sort();
+
+            // the user fields are stored by KeePass in a sorted dictionary
+            if (userFields.Count > 0)
+                standardFields.AddRange(userFields);
 
             fieldComboBox.DataSource = standardFields;
             fieldComboBox.DropDownWidth = Utils.CalculateDropDownWidth(fieldComboBox);


### PR DESCRIPTION
Disable the plugin's menu item if none of the relevant fields contain data. Previously I always added a password field to ensure there was at least one entry in the field combobox list, but that was a clunky solution for this edge case.