### PR TITLE
remove unused IComparable implementation

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -61,15 +61,6 @@ namespace FieldChooser.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Object to compare is null or of an invalid type.
-        /// </summary>
-        internal static string compare_exception {
-            get {
-                return ResourceManager.GetString("compare_exception", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap Copy {

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -133,7 +133,4 @@
   <data name="DotsDisabled" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DotsDisabled.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="compare_exception" xml:space="preserve">
-    <value>Object to compare is null or of an invalid type</value>
-  </data>
 </root>

--- a/Source/FieldChooserForm.cs
+++ b/Source/FieldChooserForm.cs
@@ -272,7 +272,7 @@ namespace FieldChooser
         }
 
 
-        private sealed class FieldEntry: IComparable<FieldEntry>, IComparable
+        private sealed class FieldEntry
         {
             // display name of the field
             private string Name { get; set; }
@@ -293,26 +293,6 @@ namespace FieldChooser
             public override string ToString()
             {
                 return Name;
-            }
-
-            [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "C# version 5 doesn't support patterns")]
-            int IComparable.CompareTo(object obj)
-            {
-                FieldEntry entry = obj as FieldEntry;
-
-                if (entry == null)
-                    throw new ArgumentException(Properties.Resources.compare_exception);
-
-                return CompareTo(entry);
-            }
-
-
-            public int CompareTo(FieldEntry other)
-            {
-                if (other == null)
-                    return -1;
-
-                return string.Compare(Name, other.Name, StringComparison.CurrentCulture);
             }
         }
 


### PR DESCRIPTION
Now that a list of FieldEntry classes doesn't need to be sorted remove the class IComparable interface implementations. This also allows the removal of a resource string that FxCop insisted was needed for an exception that could be thrown if a compare method encountered an invalid object type.