### PR TITLE
Add a tool tip to text boxes

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -61,12 +61,57 @@ namespace FieldChooser.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to C0 or C1 control code.
+        /// </summary>
+        internal static string Cc {
+            get {
+                return ResourceManager.GetString("Cc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to format control character.
+        /// </summary>
+        internal static string Cf {
+            get {
+                return ResourceManager.GetString("Cf", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unassigned character.
+        /// </summary>
+        internal static string Cn {
+            get {
+                return ResourceManager.GetString("Cn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to private use character.
+        /// </summary>
+        internal static string Co {
+            get {
+                return ResourceManager.GetString("Co", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap Copy {
             get {
                 object obj = ResourceManager.GetObject("Copy", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to suragate code point.
+        /// </summary>
+        internal static string Cs {
+            get {
+                return ResourceManager.GetString("Cs", resourceCulture);
             }
         }
         
@@ -91,6 +136,69 @@ namespace FieldChooser.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to lowercase letter.
+        /// </summary>
+        internal static string Ll {
+            get {
+                return ResourceManager.GetString("Ll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to modifier letter.
+        /// </summary>
+        internal static string Lm {
+            get {
+                return ResourceManager.GetString("Lm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to other letters, including syllables and ideographs.
+        /// </summary>
+        internal static string Lo {
+            get {
+                return ResourceManager.GetString("Lo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to digraphic character, with first part uppercase.
+        /// </summary>
+        internal static string Lt {
+            get {
+                return ResourceManager.GetString("Lt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to uppercase letter.
+        /// </summary>
+        internal static string Lu {
+            get {
+                return ResourceManager.GetString("Lu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to spacing combining mark.
+        /// </summary>
+        internal static string Mc {
+            get {
+                return ResourceManager.GetString("Mc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to enclosing combining mark.
+        /// </summary>
+        internal static string Me {
+            get {
+                return ResourceManager.GetString("Me", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap Menu_16x {
@@ -106,6 +214,168 @@ namespace FieldChooser.Properties {
         internal static string menu_text {
             get {
                 return ResourceManager.GetString("menu_text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nonspacing combining mark.
+        /// </summary>
+        internal static string Mn {
+            get {
+                return ResourceManager.GetString("Mn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to decimal digit.
+        /// </summary>
+        internal static string Nd {
+            get {
+                return ResourceManager.GetString("Nd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to letter like numeric character.
+        /// </summary>
+        internal static string Nl {
+            get {
+                return ResourceManager.GetString("Nl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to numeric character.
+        /// </summary>
+        internal static string No {
+            get {
+                return ResourceManager.GetString("No", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to punctuation mark.
+        /// </summary>
+        internal static string Pc {
+            get {
+                return ResourceManager.GetString("Pc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to dash or hyphen punctuation mark.
+        /// </summary>
+        internal static string Pd {
+            get {
+                return ResourceManager.GetString("Pd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to closing punctuation mark.
+        /// </summary>
+        internal static string Pe {
+            get {
+                return ResourceManager.GetString("Pe", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to final quotation mark.
+        /// </summary>
+        internal static string Pf {
+            get {
+                return ResourceManager.GetString("Pf", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to initial quotation mark.
+        /// </summary>
+        internal static string Pi {
+            get {
+                return ResourceManager.GetString("Pi", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to punctuation mark.
+        /// </summary>
+        internal static string Po {
+            get {
+                return ResourceManager.GetString("Po", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to opening punctuation mark.
+        /// </summary>
+        internal static string Ps {
+            get {
+                return ResourceManager.GetString("Ps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to currency symbol.
+        /// </summary>
+        internal static string Sc {
+            get {
+                return ResourceManager.GetString("Sc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to non-letterlike modifier symbol.
+        /// </summary>
+        internal static string Sk {
+            get {
+                return ResourceManager.GetString("Sk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to mathematical symbol.
+        /// </summary>
+        internal static string Sm {
+            get {
+                return ResourceManager.GetString("Sm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to symbol.
+        /// </summary>
+        internal static string So {
+            get {
+                return ResourceManager.GetString("So", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to line seperator.
+        /// </summary>
+        internal static string Zl {
+            get {
+                return ResourceManager.GetString("Zl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to paragraph seperator.
+        /// </summary>
+        internal static string Zp {
+            get {
+                return ResourceManager.GetString("Zp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to space character.
+        /// </summary>
+        internal static string Zs {
+            get {
+                return ResourceManager.GetString("Zs", resourceCulture);
             }
         }
     }

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -133,4 +133,94 @@
   <data name="DotsDisabled" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DotsDisabled.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="Cc" xml:space="preserve">
+    <value>C0 or C1 control code</value>
+  </data>
+  <data name="Cf" xml:space="preserve">
+    <value>format control character</value>
+  </data>
+  <data name="Cn" xml:space="preserve">
+    <value>unassigned character</value>
+  </data>
+  <data name="Co" xml:space="preserve">
+    <value>private use character</value>
+  </data>
+  <data name="Cs" xml:space="preserve">
+    <value>suragate code point</value>
+  </data>
+  <data name="Ll" xml:space="preserve">
+    <value>lowercase letter</value>
+  </data>
+  <data name="Lm" xml:space="preserve">
+    <value>modifier letter</value>
+  </data>
+  <data name="Lo" xml:space="preserve">
+    <value>other letters, including syllables and ideographs</value>
+  </data>
+  <data name="Lt" xml:space="preserve">
+    <value>digraphic character, with first part uppercase</value>
+  </data>
+  <data name="Lu" xml:space="preserve">
+    <value>uppercase letter</value>
+  </data>
+  <data name="Mc" xml:space="preserve">
+    <value>spacing combining mark</value>
+  </data>
+  <data name="Me" xml:space="preserve">
+    <value>enclosing combining mark</value>
+  </data>
+  <data name="Mn" xml:space="preserve">
+    <value>nonspacing combining mark</value>
+  </data>
+  <data name="Nd" xml:space="preserve">
+    <value>decimal digit</value>
+  </data>
+  <data name="Nl" xml:space="preserve">
+    <value>letter like numeric character</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>numeric character</value>
+  </data>
+  <data name="Pc" xml:space="preserve">
+    <value>punctuation mark</value>
+  </data>
+  <data name="Pd" xml:space="preserve">
+    <value>dash or hyphen punctuation mark</value>
+  </data>
+  <data name="Pe" xml:space="preserve">
+    <value>closing punctuation mark</value>
+  </data>
+  <data name="Pf" xml:space="preserve">
+    <value>final quotation mark</value>
+  </data>
+  <data name="Pi" xml:space="preserve">
+    <value>initial quotation mark</value>
+  </data>
+  <data name="Po" xml:space="preserve">
+    <value>punctuation mark</value>
+  </data>
+  <data name="Ps" xml:space="preserve">
+    <value>opening punctuation mark</value>
+  </data>
+  <data name="Sc" xml:space="preserve">
+    <value>currency symbol</value>
+  </data>
+  <data name="Sk" xml:space="preserve">
+    <value>non-letterlike modifier symbol</value>
+  </data>
+  <data name="Sm" xml:space="preserve">
+    <value>mathematical symbol</value>
+  </data>
+  <data name="So" xml:space="preserve">
+    <value>symbol</value>
+  </data>
+  <data name="Zl" xml:space="preserve">
+    <value>line seperator</value>
+  </data>
+  <data name="Zp" xml:space="preserve">
+    <value>paragraph seperator</value>
+  </data>
+  <data name="Zs" xml:space="preserve">
+    <value>space character</value>
+  </data>
 </root>

--- a/Source/FieldChooserForm.Designer.cs
+++ b/Source/FieldChooserForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.fieldComboBox = new System.Windows.Forms.ComboBox();
             this.fieldComboLabel = new System.Windows.Forms.Label();
             this.indexComboBox1 = new System.Windows.Forms.ComboBox();
@@ -42,6 +43,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.protectButton = new System.Windows.Forms.Button();
             this.copyButton = new System.Windows.Forms.Button();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
             // fieldComboBox
@@ -231,6 +233,11 @@
             this.copyButton.UseVisualStyleBackColor = true;
             this.copyButton.Click += new System.EventHandler(this.CopyButton_Click);
             // 
+            // toolTip
+            // 
+            this.toolTip.IsBalloon = true;
+            this.toolTip.Popup += new System.Windows.Forms.PopupEventHandler(this.ToolTip_Popup);
+            // 
             // FieldChooserForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -281,6 +288,7 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button copyButton;
         private System.Windows.Forms.Button protectButton;
+        private System.Windows.Forms.ToolTip toolTip;
     }
 }
 

--- a/Source/FieldChooserForm.cs
+++ b/Source/FieldChooserForm.cs
@@ -24,6 +24,7 @@ using System.Diagnostics;
 using System.Security.Permissions;
 using System.Globalization;
 using System.Drawing;
+using System.Windows.Forms.VisualStyles;
 
 using KeePass.Plugins;
 using KeePass.Resources;
@@ -33,6 +34,8 @@ using KeePassLib.Collections;
 using KeePassLib.Security;
 using KeePass.App;
 using KeePassLib.Utility;
+
+using FieldChooser.Properties;
 
 
 namespace FieldChooser
@@ -44,9 +47,9 @@ namespace FieldChooser
         private readonly List<CharacterSelectorRow> characterSelectorRows = new List<CharacterSelectorRow>();
         private int previousFieldIndex = int.MinValue;
 
-        private const string cWidthKey  = "FieldChooser.DialogInfo.Width";
-        private const string cXKey      = "FieldChooser.DialogInfo.X";
-        private const string cYKey      = "FieldChooser.DialogInfo.Y";
+        private const string cWidthKey = "FieldChooser.DialogInfo.Width";
+        private const string cXKey = "FieldChooser.DialogInfo.X";
+        private const string cYKey = "FieldChooser.DialogInfo.Y";
 
 
         private FieldChooserForm()
@@ -85,11 +88,11 @@ namespace FieldChooser
                 if (FieldChooserExt.FieldIsValid(kvp))
                 {
                     if (kvp.Key == PwDefs.PasswordField)
-                        standardFields.Insert(0, new FieldEntry(KPRes.Password, kvp.Value)); 
+                        standardFields.Insert(0, new FieldEntry(KPRes.Password, kvp.Value));
                     else if (kvp.Key == PwDefs.UserNameField)
-                        standardFields.Add(new FieldEntry(KPRes.UserName, kvp.Value)); 
+                        standardFields.Add(new FieldEntry(KPRes.UserName, kvp.Value));
                     else
-                        userFields.Add(new FieldEntry(kvp.Key, kvp.Value)); 
+                        userFields.Add(new FieldEntry(kvp.Key, kvp.Value));
                 }
             }
 
@@ -103,8 +106,7 @@ namespace FieldChooser
             fieldComboBox.DataSource = standardFields;
             fieldComboBox.DropDownWidth = Utils.CalculateDropDownWidth(fieldComboBox);
 
-            if (KeePass.Program.Config.UI.PasswordFont.OverrideUIDefault)
-                AdjustLayoutForPasswordFont();
+            AdjustLayoutForPasswordFont();
 
             // the default width and calculated height
             this.MinimumSize = new Size(this.Width, this.Height);
@@ -117,6 +119,7 @@ namespace FieldChooser
 
             this.Location = RestoreAndValidateSavedFormLocation();
         }
+
 
 
         private Point RestoreAndValidateSavedFormLocation()
@@ -153,7 +156,8 @@ namespace FieldChooser
 
             return location;
         }
-       
+
+
 
         private void AdjustLayoutForPasswordFont()
         {
@@ -169,7 +173,7 @@ namespace FieldChooser
 
                     row.CharTextBox.Font = passwordFont;
 
-                    row.CharTextBox.Top += verticalOffset; 
+                    row.CharTextBox.Top += verticalOffset;
                     row.IndexComboBox.Top += verticalOffset;
 
                     // the text box has a minimum size property so won't shrink
@@ -185,38 +189,10 @@ namespace FieldChooser
         private void FieldChooserForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             Host.CustomConfig.SetLong(cWidthKey, this.Width);
-            Host.CustomConfig.SetLong(cXKey, this.Left); 
+            Host.CustomConfig.SetLong(cXKey, this.Left);
             Host.CustomConfig.SetLong(cYKey, this.Top);
         }
 
-
-        // Windows message hit test result codes
-        private enum HitTest : int
-        {
-            Error = -2,
-            Transparent = -1,
-            Nowhere = 0,
-            Client = 1,
-            Caption = 2,
-            SysMenu = 3,
-            GrowBox = 4,
-            Menu = 5,
-            HScroll = 6,
-            VScroll = 7,
-            MinButton = 8,
-            MaxButton = 9,
-            Left = 10,
-            Right = 11,
-            Top = 12,
-            TopLeft = 13,
-            TopRight = 14,
-            Bottom = 15,
-            BottomLeft = 16,
-            BottomRight = 17,
-            Border = 18,
-            Close = 20,
-            Help = 21
-        }
 
 
         // Hijack the hit test message result stopping the OS from showing the vertical 
@@ -227,23 +203,23 @@ namespace FieldChooser
 
             base.WndProc(ref m);
 
-            if (m.Msg == WM_NCHITTEST) 
+            if (m.Msg == WM_NCHITTEST)
             {
-                HitTest result = (HitTest)m.Result.ToInt32();
+                HitTestCode result = (HitTestCode)m.Result.ToInt32();
 
                 switch (result)
                 {
-                    case HitTest.TopLeft:
-                    case HitTest.BottomLeft:
-                        m.Result = new IntPtr((int)HitTest.Left); break;
+                    case HitTestCode.TopLeft:
+                    case HitTestCode.BottomLeft:
+                        m.Result = new IntPtr((int)HitTestCode.Left); break;
 
-                    case HitTest.TopRight:
-                    case HitTest.BottomRight:
-                        m.Result = new IntPtr((int)HitTest.Right); break;
+                    case HitTestCode.TopRight:
+                    case HitTestCode.BottomRight:
+                        m.Result = new IntPtr((int)HitTestCode.Right); break;
 
-                    case HitTest.Top:
-                    case HitTest.Bottom:
-                        m.Result = new IntPtr((int)HitTest.Nowhere); break;
+                    case HitTestCode.Top:
+                    case HitTestCode.Bottom:
+                        m.Result = new IntPtr((int)HitTestCode.Nowhere); break;
                 }
             }
         }
@@ -265,7 +241,7 @@ namespace FieldChooser
                 int requiredComboBoxItemCount = pString.Length + 1;
 
                 if (indexComboBox1.Items.Count != requiredComboBoxItemCount)
-                { 
+                {
                     if (indexComboBox1.Items.Count < requiredComboBoxItemCount)
                     {
                         for (int index = indexComboBox1.Items.Count; index < requiredComboBoxItemCount; index++)
@@ -317,8 +293,8 @@ namespace FieldChooser
             {
                 if (ReferenceEquals(row.IndexComboBox, sender))
                     entryProtected = LoadCharacterTextBox(row.IndexComboBox.SelectedIndex, row.CharTextBox);
-                
-                characterSelected |= row.IndexComboBox.SelectedIndex > 0 ;
+
+                characterSelected |= row.IndexComboBox.SelectedIndex > 0;
             }
 
             protectButton.Enabled = entryProtected && characterSelected;
@@ -363,8 +339,8 @@ namespace FieldChooser
 
             return base.ProcessCmdKey(ref msg, keyData);
         }
-        
-         
+
+
 
         private void CopyButton_Click(object sender, EventArgs e)
         {
@@ -389,10 +365,11 @@ namespace FieldChooser
         private void ProtectButtonEnabledStateChanged(object sender, EventArgs e)
         {
             if (protectButton.Enabled)
-                protectButton.Image = Properties.Resources.Dots;
+                protectButton.Image = Resources.Dots;
             else
-                protectButton.Image = Properties.Resources.DotsDisabled;
+                protectButton.Image = Resources.DotsDisabled;
         }
+
 
 
         private void CharTextBox_TextChanged(object sender, EventArgs e)
@@ -400,7 +377,73 @@ namespace FieldChooser
             Debug.Assert(sender is TextBox);
 
             TextBox tb = sender as TextBox;
-            tb.Enabled = !string.IsNullOrEmpty(tb.Text);
+
+            if (string.IsNullOrEmpty(tb.Text))
+                tb.Enabled = false;
+            else
+            {
+                tb.Enabled = true;
+                toolTip.SetToolTip(tb, GetUnicodeCategoryDescription(tb.Text[0]));
+            }
+        }
+
+
+
+        private void ToolTip_Popup(object sender, PopupEventArgs e)
+        {
+            Debug.Assert(e.AssociatedControl is TextBox);
+            e.Cancel = (e.AssociatedControl as TextBox).UseSystemPasswordChar;
+        }
+
+
+
+        /// <summary>
+        /// Gets a description of the Unicode category that the supplied
+        /// character belongs to. Helps the user identify which look a 
+        /// like character they are dealing with.
+        /// </summary>
+        /// <param name="c"></param>
+        /// <returns>category description</returns>
+        private string GetUnicodeCategoryDescription(char c)
+        {
+            string s = string.Empty;
+            UnicodeCategory uc = Char.GetUnicodeCategory(c);
+
+            switch (uc)
+            {
+                case UnicodeCategory.UppercaseLetter: s = Resources.Lu; break;
+                case UnicodeCategory.LowercaseLetter: s = Resources.Ll; break;
+                case UnicodeCategory.TitlecaseLetter: s = Resources.Lt; break;
+                case UnicodeCategory.ModifierLetter: s = Resources.Lm; break;
+                case UnicodeCategory.OtherLetter: s = Resources.Lo; break;
+                case UnicodeCategory.NonSpacingMark: s = Resources.Mn; break;
+                case UnicodeCategory.SpacingCombiningMark: s = Resources.Mc; break;
+                case UnicodeCategory.EnclosingMark: s = Resources.Me; break;
+                case UnicodeCategory.DecimalDigitNumber: s = Resources.Nd; break;
+                case UnicodeCategory.LetterNumber: s = Resources.Nl; break;
+                case UnicodeCategory.OtherNumber: s = Resources.No; break;
+                case UnicodeCategory.SpaceSeparator: s = Resources.Zs; break;
+                case UnicodeCategory.LineSeparator: s = Resources.Zl; break;
+                case UnicodeCategory.ParagraphSeparator: s = Resources.Zp; break;
+                case UnicodeCategory.Control: s = Resources.Cc; break;
+                case UnicodeCategory.Format: s = Resources.Cf; break;
+                case UnicodeCategory.Surrogate: s = Resources.Cs; break;
+                case UnicodeCategory.PrivateUse: s = Resources.Co; break;
+                case UnicodeCategory.ConnectorPunctuation: s = Resources.Pc; break;
+                case UnicodeCategory.DashPunctuation: s = Resources.Pd; break;
+                case UnicodeCategory.OpenPunctuation: s = Resources.Po; break;
+                case UnicodeCategory.ClosePunctuation: s = Resources.Pc; break;
+                case UnicodeCategory.InitialQuotePunctuation: s = Resources.Pi; break;
+                case UnicodeCategory.FinalQuotePunctuation: s = Resources.Pf; break;
+                case UnicodeCategory.OtherPunctuation: s = Resources.Po; break;
+                case UnicodeCategory.MathSymbol: s = Resources.Sm; break;
+                case UnicodeCategory.CurrencySymbol: s = Resources.Sc; break;
+                case UnicodeCategory.ModifierSymbol: s = Resources.Sk; break;
+                case UnicodeCategory.OtherSymbol: s = Resources.So; break;
+                case UnicodeCategory.OtherNotAssigned: s = Resources.Cn; break;
+            }
+
+            return s;
         }
 
 
@@ -423,7 +466,7 @@ namespace FieldChooser
 
         private sealed class FieldEntry
         {
-            private string DisplayName { get; set; }
+            private string Name { get; set; }
             public ProtectedString Value { get; private set; }
 
             public FieldEntry(string name, ProtectedString value)
@@ -431,15 +474,17 @@ namespace FieldChooser
                 Debug.Assert(!string.IsNullOrEmpty(name));
                 Debug.Assert(value != null);
 
-                DisplayName = name;
+                Name = name;
                 Value = value;
             }
 
             public override string ToString()
             {
-                return DisplayName;
+                return Name;
             }
         }
+
+
 
         private static class Utils
         {
@@ -467,8 +512,8 @@ namespace FieldChooser
                 Debug.Assert(left != null);
                 Debug.Assert(right != null);
 
-                return (left.FontFamily.Equals(right.FontFamily)) && 
-                        (left.SizeInPoints == right.SizeInPoints) && 
+                return (left.FontFamily.Equals(right.FontFamily)) &&
+                        (left.SizeInPoints == right.SizeInPoints) &&
                         (left.Style == right.Style);
             }
         }

--- a/Source/FieldChooserForm.resx
+++ b/Source/FieldChooserForm.resx
@@ -159,4 +159,7 @@
   <metadata name="copyButton.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
Add a tool tip to the text boxes to show a description of the unicode category for the character displayed. A bit over engineered but should help distinguish the look a like characters and upper/lower case etc.