### PR TITLE
Bump build number to 2.0

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4")]
-[assembly: AssemblyFileVersion("1.4")]
+[assembly: AssemblyVersion("2.0")]
+[assembly: AssemblyFileVersion("2.0")]
 [assembly: NeutralResourcesLanguage("en")]
 

--- a/plugin.version
+++ b/plugin.version
@@ -1,3 +1,3 @@
 ﻿:
-CharacterChooser:1.4
+CharacterChooser:2.0
 :


### PR DESCRIPTION
KeePass will identify this as a new plugin because of the name change. But keep the existing git version tags so for this major change set to 2.0